### PR TITLE
Fix regularization using the Jacobian determinant

### DIFF
--- a/Operators/@MRMOTUS_Operator/MRMOTUS_Operator.m
+++ b/Operators/@MRMOTUS_Operator/MRMOTUS_Operator.m
@@ -760,7 +760,7 @@ classdef MRMOTUS_Operator
                             dydy = permute(RegularizationOptions.Types.Determinant.BasisXDyZ.Value*squeeze(MotionField(:,2,:))+1,[1 3 2]);
                             dydz = permute(RegularizationOptions.Types.Determinant.BasisXYDz.Value*squeeze(MotionField(:,2,:)),[1 3 2]);
                             dzdx = permute(RegularizationOptions.Types.Determinant.BasisDxYZ.Value*squeeze(MotionField(:,3,:)),[1 3 2]);
-                            dzdy = permute(RegularizationOptions.Types.Determinant.BasisXDyZ*squeeze(MotionField(:,3,:)),[1 3 2]);
+                            dzdy = permute(RegularizationOptions.Types.Determinant.BasisXDyZ.Value*squeeze(MotionField(:,3,:)),[1 3 2]);
                             dzdz = permute(RegularizationOptions.Types.Determinant.BasisXYDz.Value*squeeze(MotionField(:,3,:))+1,[1 3 2]);
                             
 

--- a/Operators/@MRMOTUS_Operator/MRMOTUS_Operator.m
+++ b/Operators/@MRMOTUS_Operator/MRMOTUS_Operator.m
@@ -782,7 +782,7 @@ classdef MRMOTUS_Operator
                             
                             ObjfuncValDynamic = ObjfuncValDynamic + RegularizationOptions.Types.Determinant.Lambda*(0.5*norm(dtminone(:)).^2);
                             clearvars dtminone
-                            GradientDynamic = GradientDynamic  + reshape(RegularizationOptions.Types.Determinant.Lambda * ([RegularizationOptions.Types.Determinant.BasisDxYZ.Value.',RegularizationOptions.Types.Determinant.BasisXDyZ.Value.',RegularizationOptions.Types.Determinant.BasisXYDz.Value.'] * B),[],3,v);
+                            GradientDynamic = GradientDynamic  + reshape(RegularizationOptions.Types.Determinant.Lambda * ([RegularizationOptions.Types.Determinant.BasisDxYZ.Value.',RegularizationOptions.Types.Determinant.BasisXDyZ.Value.',RegularizationOptions.Types.Determinant.BasisXYDz.Value.'] * double(B)),[],3,v);
 
                             
                         elseif size(MotionField,2)==2 %2D
@@ -803,7 +803,7 @@ classdef MRMOTUS_Operator
                                 B_1 = reshape(bsxfun(@times,static_struct.referenceImage.*static_struct.referenceImage.*dtminone,[(dydy(:)+1),-dydx(:)]),[],1); % derivative to x coefficients: to dxdx & dxdy. Bases: DxY, XDy
                                 B_2 = reshape(bsxfun(@times,static_struct.referenceImage.*static_struct.referenceImage.*dtminone,[-dxdy(:),(dxdx(:)+1)]),[],1); % derivative to y coefficients: to dydx & dydy. Bases: DxY, XDy
 
-                                GradientDynamic(:,:,d) = GradientDynamic(:,:,d)  + RegularizationOptions.Types.Determinant.Lambda * RegularizationOptions.Types.Determinant.A_1.Value * [B_1 , B_2];
+                                GradientDynamic(:,:,d) = GradientDynamic(:,:,d)  + RegularizationOptions.Types.Determinant.Lambda * RegularizationOptions.Types.Determinant.A_1.Value * double([B_1 , B_2]);
                                 
                             
                             end

--- a/Operators/@MRMOTUS_Operator/MRMOTUS_Operator.m
+++ b/Operators/@MRMOTUS_Operator/MRMOTUS_Operator.m
@@ -782,7 +782,7 @@ classdef MRMOTUS_Operator
                             
                             ObjfuncValDynamic = ObjfuncValDynamic + RegularizationOptions.Types.Determinant.Lambda*(0.5*norm(dtminone(:)).^2);
                             clearvars dtminone
-                            GradientDynamic = GradientDynamic  + reshape(RegularizationOptions.Types.Determinant.Lambda * ([RegularizationOptions.Types.Determinant.BasisDxYZ.Value.',RegularizationOptions.Types.Determinant.BasisXDyZ.Value.',RegularizationOptions.Types.Determinant.BasisXYDz.Value.'] * double(B)),[],3,v);
+                            GradientDynamic = GradientDynamic  + reshape(RegularizationOptions.Types.Determinant.Lambda * (RegularizationOptions.Types.Determinant.A_1.Value * double(B)),[],3,v);
 
                             
                         elseif size(MotionField,2)==2 %2D


### PR DESCRIPTION
There are two minor problems inside the single-dynamic regularization part that is using the Jacobian determinant:

- a syntactical problem: missing field access when using a struct
- a problem with the compatibility of different Matlab data types: Matlab's sparse matrices are always of double precision (i.e., 'A_1') and cannot be multiplied with single precision dense matrices (i.e., 'B'). This can be either solved by converting the sparse double precision matrix into a dense single precision matrix or converting the dense single precision matrix into a dense double precision matrix. The second of those solutions is preferable as it uses less memory.

Both problems go unnoticed by default, because the included parameters for both 2DGA and 3DGMR reconstructions set the appropriate lambda value to zero which prevents execution of the broken code path. This pull requests corrects both problems and additionally makes use of a pre-concatenated 'A_1' value instead of concatenating the value (and creating a copy of its memory) for each iteration and every dynamic.